### PR TITLE
Fix bug for variable getters/setters in interators

### DIFF
--- a/blocklyduino/arduino/typed_variable.js
+++ b/blocklyduino/arduino/typed_variable.js
@@ -58,3 +58,15 @@ Blockly.Arduino['vars_get_boolean'] = function (block) {
     var code = Blockly.Arduino.variableDB_.getName(block.getFieldValue('VAR_GET_BOOLEAN'), Blockly.Variables.NAME_TYPE);
     return [code, Blockly.Arduino.ORDER_ATOMIC];
 };
+
+Blockly.Arduino['variables_set'] = function(block) {
+    var argument0 = Blockly.Arduino.valueToCode(block, 'VALUE', Blockly.Arduino.ORDER_ASSIGNMENT) || '0';
+    var varName = Blockly.Arduino.variableDB_.getName(block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
+    return varName + ' = ' + argument0 + ';\n';
+};
+
+Blockly.Arduino['variables_get'] = function(block) {
+    var code = Blockly.Arduino.variableDB_.getName(block.getFieldValue('VAR'), Blockly.VARIABLE_CATEGORY_NAME);
+    return [code, Blockly.Arduino.ORDER_ATOMIC];
+};
+


### PR DESCRIPTION
Bug: In iterator blocks (i.e. for loop), right clicking and getting (or setting once gotten) a generic variable would cause an error and not generate code in the preview window.